### PR TITLE
[ROY-52] Fix create-worktree script to properly setup environment

### DIFF
--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -71,7 +71,9 @@ check_claude_available() {
     claude_path=$(get_claude_path)
     
     if [ -z "$claude_path" ]; then
+        local claude_home="${CLAUDE_HOME:-$HOME/.claude/local}"
         print_error "Claude Code CLI not found. Please install it first."
+        print_info "Expected location: $claude_home/claude or in PATH"
         print_info "Visit https://claude.ai/code for installation instructions"
         return 1
     fi
@@ -136,6 +138,15 @@ main() {
 
     print_info "Processing ticket $ticket_id"
 
+    # Check dependencies early
+    if ! check_claude_available; then
+        exit 1
+    fi
+    
+    if ! check_uv_available; then
+        exit 1
+    fi
+
     # Get git root directory
     local git_root
     git_root=$(get_git_root)
@@ -175,19 +186,26 @@ main() {
     # Get branch name from Linear
     print_info "Fetching branch name from Linear for $ticket_id..."
     local branch_name
+    local claude_cmd
+    claude_cmd=$(get_claude_path)
     
-    if check_claude_available; then
-        local claude_cmd
-        claude_cmd=$(get_claude_path)
-        branch_name=$($claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>/dev/null | tail -n 1)
-        
-        # Fallback if Claude doesn't provide a valid branch name
-        if [[ ! "$branch_name" =~ ^farmisen/.*$ ]]; then
-            branch_name="farmisen/${ticket_slug}-feature"
-        fi
-    else
-        # Fallback branch name if Claude is not available
-        branch_name="farmisen/${ticket_slug}-feature"
+    branch_name=$($claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
+    
+    # Check if Claude command failed
+    if [ $? -ne 0 ]; then
+        print_error "Failed to fetch branch name from Linear"
+        print_info "Claude output: $branch_name"
+        exit 1
+    fi
+    
+    # Extract the last line (the branch name)
+    branch_name=$(echo "$branch_name" | tail -n 1)
+    
+    # Validate the branch name format
+    if [[ ! "$branch_name" =~ ^farmisen/.*$ ]]; then
+        print_error "Invalid branch name received from Linear: '$branch_name'"
+        print_info "Expected format: farmisen/<ticket-id>-<description>"
+        exit 1
     fi
 
     print_info "Using branch name: $branch_name"

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -204,6 +204,12 @@ main() {
         $claude_cmd --version || print_error "Failed to get claude version"
 
         print_info "Fetching branch name from Linear..."
+        
+        # Debug: Try running without capturing output first
+        print_info "Debug: Running command directly (not capturing output)..."
+        gtimeout 5s $claude_cmd --print "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else."
+        print_info "Debug: Direct command completed"
+        
         print_info "Running: gtimeout 30s $claude_cmd --print \"Fetch the git branch name...\""
         branch_name=$(gtimeout 30s $claude_cmd --print "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
         local exit_code=$?

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -220,8 +220,8 @@ main() {
             exit 1
         fi
 
-        # Extract the last line (the branch name)
-        branch_name=$(echo "$branch_name" | tail -n 1)
+        # Extract the last line (the branch name) and remove backticks if present
+        branch_name=$(echo "$branch_name" | tail -n 1 | sed 's/^`//' | sed 's/`$//')
         
         # Validate the branch name format
         if [[ ! "$branch_name" =~ ^farmisen/.*$ ]]; then

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -203,11 +203,12 @@ main() {
         print_info "Checking claude version..."
         $claude_cmd --version || print_error "Failed to get claude version"
 
-        print_info "Fetching branch name from Linear..."
-        print_info "Running: gtimeout 30s $claude_cmd --no-interactive \"Fetch the git branch name...\""
-        branch_name=$(gtimeout 30s $claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
+        print_info "Fetching branch name from Linear (without timeout for debugging)..."
+        print_info "Running: $claude_cmd --no-interactive \"Fetch the git branch name...\""
+        branch_name=$($claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
         local exit_code=$?
         print_info "Command completed with exit code: $exit_code"
+        print_info "Claude output (first 500 chars): ${branch_name:0:500}"
 
         # Check if Claude command failed or timed out
         if [ $exit_code -eq 124 ]; then

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -204,8 +204,10 @@ main() {
         $claude_cmd --version || print_error "Failed to get claude version"
 
         print_info "Fetching branch name from Linear..."
+        print_info "Running: gtimeout 30s $claude_cmd --no-interactive \"Fetch the git branch name...\""
         branch_name=$(gtimeout 30s $claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
         local exit_code=$?
+        print_info "Command completed with exit code: $exit_code"
 
         # Check if Claude command failed or timed out
         if [ $exit_code -eq 124 ]; then

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -189,11 +189,18 @@ main() {
     local claude_cmd
     claude_cmd=$(get_claude_path)
     
-    branch_name=$($claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
+    print_info "Using claude command: $claude_cmd"
     
-    # Check if Claude command failed
-    if [ $? -ne 0 ]; then
-        print_error "Failed to fetch branch name from Linear"
+    # Run claude with timeout to prevent hanging
+    branch_name=$(timeout 30s $claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
+    local exit_code=$?
+    
+    # Check if Claude command failed or timed out
+    if [ $exit_code -eq 124 ]; then
+        print_error "Claude command timed out after 30 seconds"
+        exit 1
+    elif [ $exit_code -ne 0 ]; then
+        print_error "Failed to fetch branch name from Linear (exit code: $exit_code)"
         print_info "Claude output: $branch_name"
         exit 1
     fi
@@ -247,6 +254,7 @@ main() {
         print_info "Launching Claude Code to implement $ticket_id..."
         local claude_cmd
         claude_cmd=$(get_claude_path)
+        # Don't use timeout for interactive claude session
         $claude_cmd "Please implement Linear ticket $ticket_id. Start by fetching the ticket details from Linear." &
         print_success "Claude Code launched in the background"
     fi

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -53,6 +53,44 @@ check_claude_available() {
     return 0
 }
 
+check_uv_available() {
+    if ! command -v uv &> /dev/null; then
+        print_error "uv not found. Please install it first."
+        print_info "Visit https://github.com/astral-sh/uv for installation instructions"
+        return 1
+    fi
+    return 0
+}
+
+setup_python_environment() {
+    local worktree_path="$1"
+    
+    print_info "Setting up Python environment with uv..."
+    
+    # Check if uv is available
+    if ! check_uv_available; then
+        print_error "Cannot setup Python environment without uv"
+        return 1
+    fi
+    
+    # Create virtual environment
+    print_info "Creating virtual environment..."
+    if ! uv venv; then
+        print_error "Failed to create virtual environment"
+        return 1
+    fi
+    
+    # Install dependencies
+    print_info "Installing project dependencies..."
+    if ! uv pip install -e ".[dev]"; then
+        print_error "Failed to install dependencies"
+        return 1
+    fi
+    
+    print_success "Python environment setup complete"
+    return 0
+}
+
 # Main script
 main() {
     # Check if ticket ID is provided
@@ -151,6 +189,19 @@ main() {
 
     print_success "Worktree created successfully!"
     print_info "You are now in: $worktree_path"
+    
+    # Setup Python environment
+    setup_python_environment "$worktree_path"
+    
+    # Ensure PATH includes user's local bin for claude command
+    export PATH="$HOME/.local/bin:$PATH"
+    
+    # Source shell profile to ensure claude is available
+    if [ -f "$HOME/.bashrc" ]; then
+        source "$HOME/.bashrc"
+    elif [ -f "$HOME/.zshrc" ]; then
+        source "$HOME/.zshrc"
+    fi
     
     # Launch Claude if available
     if check_claude_available; then

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -45,7 +45,8 @@ get_git_root() {
 }
 
 check_claude_available() {
-    if ! command -v claude &> /dev/null; then
+    # Check if claude command is available (works with aliases too)
+    if ! type claude &> /dev/null; then
         print_error "Claude Code CLI not found. Please install it first."
         print_info "Visit https://claude.ai/code for installation instructions"
         return 1
@@ -146,12 +147,24 @@ main() {
     print_info "Pulling latest changes from main..."
     git pull origin main
 
-    # Get branch name from Claude
-    print_info "Getting branch name suggestion for $ticket_id..."
+    # Get branch name from Linear
+    print_info "Fetching branch name from Linear for $ticket_id..."
     local branch_name
     
+    # Enable alias expansion for non-interactive shells
+    shopt -s expand_aliases 2>/dev/null || true
+    
+    # Source profile to get claude alias
+    if [ -n "$BASH_VERSION" ] && [ -f "$HOME/.bashrc" ]; then
+        source "$HOME/.bashrc"
+    elif [ -n "$ZSH_VERSION" ] && [ -f "$HOME/.zshrc" ]; then
+        source "$HOME/.zshrc"
+    elif [ -f "$HOME/.bash_profile" ]; then
+        source "$HOME/.bash_profile"
+    fi
+    
     if check_claude_available; then
-        branch_name=$(claude --no-interactive "For Linear ticket $ticket_id, suggest a git branch name following the pattern: farmisen/<ticket-id>-<descriptive-name>. Output only the branch name, nothing else." 2>/dev/null | tail -n 1)
+        branch_name=$(claude --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>/dev/null | tail -n 1)
         
         # Fallback if Claude doesn't provide a valid branch name
         if [[ ! "$branch_name" =~ ^farmisen/.*$ ]]; then
@@ -196,11 +209,15 @@ main() {
     # Ensure PATH includes user's local bin for claude command
     export PATH="$HOME/.local/bin:$PATH"
     
-    # Source shell profile to ensure claude is available
-    if [ -f "$HOME/.bashrc" ]; then
+    # Source shell profile to ensure claude alias is available
+    if [ -n "$BASH_VERSION" ] && [ -f "$HOME/.bashrc" ]; then
         source "$HOME/.bashrc"
-    elif [ -f "$HOME/.zshrc" ]; then
+    elif [ -n "$ZSH_VERSION" ] && [ -f "$HOME/.zshrc" ]; then
         source "$HOME/.zshrc"
+    elif [ -f "$HOME/.bash_profile" ]; then
+        source "$HOME/.bash_profile"
+    elif [ -f "$HOME/.profile" ]; then
+        source "$HOME/.profile"
     fi
     
     # Launch Claude if available

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -201,10 +201,10 @@ main() {
     if check_claude_available; then
         # Check claude version for debugging
         print_info "Checking claude version..."
-        claude --version || print_error "Failed to get claude version"
+        $claude_cmd --version || print_error "Failed to get claude version"
 
         print_info "Fetching branch name from Linear..."
-        branch_name=$(gtimeout 30s claude --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
+        branch_name=$(gtimeout 30s $claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
         local exit_code=$?
 
         # Check if Claude command failed or timed out
@@ -220,9 +220,11 @@ main() {
         # Extract the last line (the branch name)
         branch_name=$(echo "$branch_name" | tail -n 1)
         
-        # Fallback if Claude doesn't provide a valid branch name
+        # Validate the branch name format
         if [[ ! "$branch_name" =~ ^farmisen/.*$ ]]; then
-            branch_name="farmisen/${ticket_slug}-feature"
+            print_error "Invalid branch name received from Linear: '$branch_name'"
+            print_info "Expected format: farmisen/<ticket-id>-<description>"
+            exit 1
         fi
     else
         # Fallback branch name if Claude is not available

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -203,9 +203,9 @@ main() {
         print_info "Checking claude version..."
         $claude_cmd --version || print_error "Failed to get claude version"
 
-        print_info "Fetching branch name from Linear (without timeout for debugging)..."
-        print_info "Running: $claude_cmd --no-interactive \"Fetch the git branch name...\""
-        branch_name=$($claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
+        print_info "Fetching branch name from Linear..."
+        print_info "Running: gtimeout 30s $claude_cmd --print \"Fetch the git branch name...\""
+        branch_name=$(gtimeout 30s $claude_cmd --print "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
         local exit_code=$?
         print_info "Command completed with exit code: $exit_code"
         print_info "Claude output (first 500 chars): ${branch_name:0:500}"

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -151,16 +151,9 @@ main() {
     print_info "Fetching branch name from Linear for $ticket_id..."
     local branch_name
     
-    # Enable alias expansion for non-interactive shells
-    shopt -s expand_aliases 2>/dev/null || true
-    
-    # Source profile to get claude alias
-    if [ -n "$BASH_VERSION" ] && [ -f "$HOME/.bashrc" ]; then
-        source "$HOME/.bashrc"
-    elif [ -n "$ZSH_VERSION" ] && [ -f "$HOME/.zshrc" ]; then
+    # Source zsh profile to get claude alias (assuming zsh shell)
+    if [ -f "$HOME/.zshrc" ]; then
         source "$HOME/.zshrc"
-    elif [ -f "$HOME/.bash_profile" ]; then
-        source "$HOME/.bash_profile"
     fi
     
     if check_claude_available; then
@@ -209,15 +202,9 @@ main() {
     # Ensure PATH includes user's local bin for claude command
     export PATH="$HOME/.local/bin:$PATH"
     
-    # Source shell profile to ensure claude alias is available
-    if [ -n "$BASH_VERSION" ] && [ -f "$HOME/.bashrc" ]; then
-        source "$HOME/.bashrc"
-    elif [ -n "$ZSH_VERSION" ] && [ -f "$HOME/.zshrc" ]; then
+    # Source zsh profile to ensure claude alias is available (assuming zsh shell)
+    if [ -f "$HOME/.zshrc" ]; then
         source "$HOME/.zshrc"
-    elif [ -f "$HOME/.bash_profile" ]; then
-        source "$HOME/.bash_profile"
-    elif [ -f "$HOME/.profile" ]; then
-        source "$HOME/.profile"
     fi
     
     # Launch Claude if available

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -44,13 +44,38 @@ get_git_root() {
     }
 }
 
+get_claude_path() {
+    # Use CLAUDE_HOME env var, defaulting to ~/.claude/local
+    local claude_home="${CLAUDE_HOME:-$HOME/.claude/local}"
+    local claude_path="$claude_home/claude"
+    
+    # Check if claude executable exists at CLAUDE_HOME location
+    if [ -f "$claude_path" ] && [ -x "$claude_path" ]; then
+        echo "$claude_path"
+        return 0
+    fi
+    
+    # Fallback to checking if claude is in PATH
+    if command -v claude &> /dev/null; then
+        echo "claude"
+        return 0
+    fi
+    
+    # Return empty string if not found
+    echo ""
+    return 1
+}
+
 check_claude_available() {
-    # Check if claude command is available (works with aliases too)
-    if ! type claude &> /dev/null; then
+    local claude_path
+    claude_path=$(get_claude_path)
+    
+    if [ -z "$claude_path" ]; then
         print_error "Claude Code CLI not found. Please install it first."
         print_info "Visit https://claude.ai/code for installation instructions"
         return 1
     fi
+    
     return 0
 }
 
@@ -152,11 +177,8 @@ main() {
     local branch_name
     
     if check_claude_available; then
-        # Use the full path to claude if it's an alias
-        local claude_cmd="claude"
-        if [ -f "$HOME/.claude/local/claude" ]; then
-            claude_cmd="$HOME/.claude/local/claude"
-        fi
+        local claude_cmd
+        claude_cmd=$(get_claude_path)
         branch_name=$($claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>/dev/null | tail -n 1)
         
         # Fallback if Claude doesn't provide a valid branch name
@@ -205,11 +227,8 @@ main() {
     # Launch Claude if available
     if check_claude_available; then
         print_info "Launching Claude Code to implement $ticket_id..."
-        # Use the full path to claude if it's an alias
-        local claude_cmd="claude"
-        if [ -f "$HOME/.claude/local/claude" ]; then
-            claude_cmd="$HOME/.claude/local/claude"
-        fi
+        local claude_cmd
+        claude_cmd=$(get_claude_path)
         $claude_cmd "Please implement Linear ticket $ticket_id. Start by fetching the ticket details from Linear." &
         print_success "Claude Code launched in the background"
     fi

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -154,13 +154,6 @@ main() {
         exit 1
     fi
 
-    # Check for gtimeout (GNU coreutils on macOS)
-    if ! command -v gtimeout &> /dev/null; then
-        print_error "gtimeout not found. Please install GNU coreutils first."
-        print_info "Run: brew install coreutils"
-        exit 1
-    fi
-
     # Get git root directory
     local git_root
     git_root=$(get_git_root)
@@ -206,22 +199,14 @@ main() {
     print_info "Using claude command: $claude_cmd"
 
     if check_claude_available; then
-        # Check claude version for debugging
-        print_info "Checking claude version..."
-        $claude_cmd --version || print_error "Failed to get claude version"
-
         print_info "Fetching branch name from Linear..."
-        print_info "Running: gtimeout 30s $claude_cmd --print \"Fetch the git branch name...\"" 
-        branch_name=$(gtimeout 30s $claude_cmd --print "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
+        branch_name=$($claude_cmd --print "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
         local exit_code=$?
         print_info "Command completed with exit code: $exit_code"
         print_info "Claude output (first 500 chars): ${branch_name:0:500}"
 
-        # Check if Claude command failed or timed out
-        if [ $exit_code -eq 124 ]; then
-            print_error "Claude command timed out after 30 seconds"
-            exit 1
-        elif [ $exit_code -ne 0 ]; then
+        # Check if Claude command failed
+        if [ $exit_code -ne 0 ]; then
             print_error "Failed to fetch branch name from Linear (exit code: $exit_code)"
             print_info "Claude output: $branch_name"
             exit 1
@@ -237,8 +222,8 @@ main() {
             exit 1
         fi
     else
-        # Fallback branch name if Claude is not available
-        branch_name="farmisen/${ticket_slug}-feature"
+        print_error "Cannot fetch branch name from Linear without Claude Code CLI"
+        exit 1
     fi
 
     print_info "Using branch name: $branch_name"
@@ -280,13 +265,12 @@ main() {
         print_info "Launching Claude Code to implement $ticket_id..."
         local claude_cmd
         claude_cmd=$(get_claude_path)
-        # Don't use timeout for interactive claude session
-        $claude_cmd "Please implement Linear ticket $ticket_id. Start by fetching the ticket details from Linear." &
-        print_success "Claude Code launched in the background"
+        # Launch claude in interactive mode (foreground)
+        exec $claude_cmd "Please implement Linear ticket $ticket_id. Start by fetching the ticket details from Linear."
+    else
+        # Start a new shell in the worktree directory if claude is not available
+        exec "$SHELL"
     fi
-
-    # Start a new shell in the worktree directory
-    exec "$SHELL"
 }
 
 # Run main function

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -48,19 +48,19 @@ get_claude_path() {
     # Use CLAUDE_HOME env var, defaulting to ~/.claude/local
     local claude_home="${CLAUDE_HOME:-$HOME/.claude/local}"
     local claude_path="$claude_home/claude"
-    
+
     # Check if claude executable exists at CLAUDE_HOME location
     if [ -f "$claude_path" ] && [ -x "$claude_path" ]; then
         echo "$claude_path"
         return 0
     fi
-    
+
     # Fallback to checking if claude is in PATH
     if command -v claude &> /dev/null; then
         echo "claude"
         return 0
     fi
-    
+
     # Return empty string if not found
     echo ""
     return 1
@@ -69,7 +69,7 @@ get_claude_path() {
 check_claude_available() {
     local claude_path
     claude_path=$(get_claude_path)
-    
+
     if [ -z "$claude_path" ]; then
         local claude_home="${CLAUDE_HOME:-$HOME/.claude/local}"
         print_error "Claude Code CLI not found. Please install it first."
@@ -77,7 +77,7 @@ check_claude_available() {
         print_info "Visit https://claude.ai/code for installation instructions"
         return 1
     fi
-    
+
     return 0
 }
 
@@ -92,29 +92,29 @@ check_uv_available() {
 
 setup_python_environment() {
     local worktree_path="$1"
-    
+
     print_info "Setting up Python environment with uv..."
-    
+
     # Check if uv is available
     if ! check_uv_available; then
         print_error "Cannot setup Python environment without uv"
         return 1
     fi
-    
+
     # Create virtual environment
     print_info "Creating virtual environment..."
     if ! uv venv; then
         print_error "Failed to create virtual environment"
         return 1
     fi
-    
+
     # Install dependencies
     print_info "Installing project dependencies..."
     if ! uv pip install -e ".[dev]"; then
         print_error "Failed to install dependencies"
         return 1
     fi
-    
+
     print_success "Python environment setup complete"
     return 0
 }
@@ -142,11 +142,11 @@ main() {
     if ! check_claude_available; then
         exit 1
     fi
-    
+
     if ! check_uv_available; then
         exit 1
     fi
-    
+
     # Check for gtimeout (GNU coreutils on macOS)
     if ! command -v gtimeout &> /dev/null; then
         print_error "gtimeout not found. Please install GNU coreutils first."
@@ -195,31 +195,38 @@ main() {
     local branch_name
     local claude_cmd
     claude_cmd=$(get_claude_path)
-    
+
     print_info "Using claude command: $claude_cmd"
-    
-    # Run claude with timeout to prevent hanging (using gtimeout on macOS)
-    branch_name=$(gtimeout 30s $claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
-    local exit_code=$?
-    
-    # Check if Claude command failed or timed out
-    if [ $exit_code -eq 124 ]; then
-        print_error "Claude command timed out after 30 seconds"
-        exit 1
-    elif [ $exit_code -ne 0 ]; then
-        print_error "Failed to fetch branch name from Linear (exit code: $exit_code)"
-        print_info "Claude output: $branch_name"
-        exit 1
-    fi
-    
-    # Extract the last line (the branch name)
-    branch_name=$(echo "$branch_name" | tail -n 1)
-    
-    # Validate the branch name format
-    if [[ ! "$branch_name" =~ ^farmisen/.*$ ]]; then
-        print_error "Invalid branch name received from Linear: '$branch_name'"
-        print_info "Expected format: farmisen/<ticket-id>-<description>"
-        exit 1
+
+    if check_claude_available; then
+        # Check claude version for debugging
+        print_info "Checking claude version..."
+        claude --version || print_error "Failed to get claude version"
+
+        print_info "Fetching branch name from Linear..."
+        branch_name=$(gtimeout 30s claude --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
+        local exit_code=$?
+
+        # Check if Claude command failed or timed out
+        if [ $exit_code -eq 124 ]; then
+            print_error "Claude command timed out after 30 seconds"
+            exit 1
+        elif [ $exit_code -ne 0 ]; then
+            print_error "Failed to fetch branch name from Linear (exit code: $exit_code)"
+            print_info "Claude output: $branch_name"
+            exit 1
+        fi
+
+        # Extract the last line (the branch name)
+        branch_name=$(echo "$branch_name" | tail -n 1)
+        
+        # Fallback if Claude doesn't provide a valid branch name
+        if [[ ! "$branch_name" =~ ^farmisen/.*$ ]]; then
+            branch_name="farmisen/${ticket_slug}-feature"
+        fi
+    else
+        # Fallback branch name if Claude is not available
+        branch_name="farmisen/${ticket_slug}-feature"
     fi
 
     print_info "Using branch name: $branch_name"
@@ -252,10 +259,10 @@ main() {
     
     # Setup Python environment
     setup_python_environment "$worktree_path"
-    
+
     # Ensure PATH includes user's local bin for claude command
     export PATH="$HOME/.local/bin:$PATH"
-    
+
     # Launch Claude if available
     if check_claude_available; then
         print_info "Launching Claude Code to implement $ticket_id..."

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -211,13 +211,7 @@ main() {
         $claude_cmd --version || print_error "Failed to get claude version"
 
         print_info "Fetching branch name from Linear..."
-        
-        # Debug: Try running without capturing output first
-        print_info "Debug: Running command directly (not capturing output)..."
-        gtimeout 5s $claude_cmd --print "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else."
-        print_info "Debug: Direct command completed"
-        
-        print_info "Running: gtimeout 30s $claude_cmd --print \"Fetch the git branch name...\""
+        print_info "Running: gtimeout 30s $claude_cmd --print \"Fetch the git branch name...\"" 
         branch_name=$(gtimeout 30s $claude_cmd --print "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
         local exit_code=$?
         print_info "Command completed with exit code: $exit_code"

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -151,13 +151,13 @@ main() {
     print_info "Fetching branch name from Linear for $ticket_id..."
     local branch_name
     
-    # Source zsh profile to get claude alias (assuming zsh shell)
-    if [ -f "$HOME/.zshrc" ]; then
-        source "$HOME/.zshrc"
-    fi
-    
     if check_claude_available; then
-        branch_name=$(claude --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>/dev/null | tail -n 1)
+        # Use the full path to claude if it's an alias
+        local claude_cmd="claude"
+        if [ -f "$HOME/.claude/local/claude" ]; then
+            claude_cmd="$HOME/.claude/local/claude"
+        fi
+        branch_name=$($claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>/dev/null | tail -n 1)
         
         # Fallback if Claude doesn't provide a valid branch name
         if [[ ! "$branch_name" =~ ^farmisen/.*$ ]]; then
@@ -202,15 +202,15 @@ main() {
     # Ensure PATH includes user's local bin for claude command
     export PATH="$HOME/.local/bin:$PATH"
     
-    # Source zsh profile to ensure claude alias is available (assuming zsh shell)
-    if [ -f "$HOME/.zshrc" ]; then
-        source "$HOME/.zshrc"
-    fi
-    
     # Launch Claude if available
     if check_claude_available; then
         print_info "Launching Claude Code to implement $ticket_id..."
-        claude "Please implement Linear ticket $ticket_id. Start by fetching the ticket details from Linear." &
+        # Use the full path to claude if it's an alias
+        local claude_cmd="claude"
+        if [ -f "$HOME/.claude/local/claude" ]; then
+            claude_cmd="$HOME/.claude/local/claude"
+        fi
+        $claude_cmd "Please implement Linear ticket $ticket_id. Start by fetching the ticket details from Linear." &
         print_success "Claude Code launched in the background"
     fi
 

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -4,6 +4,13 @@ set -euo pipefail
 # Script to create a git worktree for a Linear ticket
 # Usage: ./create-worktree <ticket-id>
 
+# If we're not already running from temp, copy ourselves to temp and re-exec
+if [[ "$0" != /tmp/* ]]; then
+    cp "$0" /tmp/create-worktree-$$
+    chmod +x /tmp/create-worktree-$$
+    exec /tmp/create-worktree-$$ "$@"
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -146,6 +146,13 @@ main() {
     if ! check_uv_available; then
         exit 1
     fi
+    
+    # Check for gtimeout (GNU coreutils on macOS)
+    if ! command -v gtimeout &> /dev/null; then
+        print_error "gtimeout not found. Please install GNU coreutils first."
+        print_info "Run: brew install coreutils"
+        exit 1
+    fi
 
     # Get git root directory
     local git_root
@@ -191,8 +198,8 @@ main() {
     
     print_info "Using claude command: $claude_cmd"
     
-    # Run claude with timeout to prevent hanging
-    branch_name=$(timeout 30s $claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
+    # Run claude with timeout to prevent hanging (using gtimeout on macOS)
+    branch_name=$(gtimeout 30s $claude_cmd --no-interactive "Fetch the git branch name for Linear ticket $ticket_id using the Linear MCP tool. Output only the branch name, nothing else." 2>&1)
     local exit_code=$?
     
     # Check if Claude command failed or timed out


### PR DESCRIPTION
## Summary
- Fixed create-worktree script to properly detect Claude Code CLI and setup Python environment
- Added automatic Python environment creation using uv package manager
- Resolved script hanging issues and improved error handling

## Changes
- **Claude Detection**: Now uses CLAUDE_HOME environment variable (defaults to ~/.claude/local) to find claude executable
- **Python Setup**: Automatically creates virtual environment and installs dev dependencies using uv
- **Script Stability**: Fixed hanging issues by implementing self-copy mechanism to /tmp
- **Interactive Mode**: Claude now launches in foreground for better user interaction
- **Error Handling**: Script fails fast if dependencies are missing or if Linear branch name cannot be fetched

## Test plan
- [x] Tested script with valid ticket (ROY-39) - successfully created worktree with Python environment
- [x] Tested script with invalid ticket (ROY-99) - properly failed with error message
- [x] Tested script with existing worktree - prompted user appropriately
- [x] Verified Claude launches in interactive mode (foreground)
- [x] Verified script fails if Claude cannot fetch branch name (no generic fallback)

🤖 Generated with [Claude Code](https://claude.ai/code)