### PR TITLE
[ROY-53] Add CLAUDE.md symlink to create-worktree script

### DIFF
--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -251,6 +251,14 @@ main() {
         cd "$worktree_path"
     fi
 
+    # Check if CLAUDE.md exists in main repo
+    if [ -f "${git_root}/CLAUDE.md" ]; then
+        print_info "Creating symlink for CLAUDE.md..."
+        ln -s "${git_root}/CLAUDE.md" "${worktree_path}/CLAUDE.md"
+    else
+        print_info "CLAUDE.md not found in main repository, skipping symlink"
+    fi
+
     print_success "Worktree created successfully!"
     print_info "You are now in: $worktree_path"
     


### PR DESCRIPTION
## Summary
- Added CLAUDE.md symlink functionality to the create-worktree script
- Ensures Claude Code has access to project-specific instructions in all worktrees
- Follows the same pattern as the existing .envrc symlink

## Changes
- Check if CLAUDE.md exists in main repository
- Create symlink if file exists
- Skip with informative message if file doesn't exist

## Test plan
- [x] Tested script with ROY-41 - successfully created CLAUDE.md symlink
- [x] Verified symlink points to correct location in main repository
- [x] Confirmed script handles missing CLAUDE.md gracefully
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)