### PR TITLE
[ROY-55] Fix MCP server command parsing in create-worktree script

### DIFF
--- a/.claude-worktrees.rc
+++ b/.claude-worktrees.rc
@@ -2,9 +2,9 @@
 # This file defines MCP servers and files to symlink for git worktrees
 
 # MCP Server Configuration
-# Format: SERVER_NAME|COMMAND|ARG1|ARG2|...
+# Format: SERVER_NAME|FULL_COMMAND
 MCP_SERVERS="
-linear|npx|-y|mcp-remote|https://mcp.linear.app/sse
+linear|npx -y mcp-remote https://mcp.linear.app/sse
 "
 
 # Files to symlink from main repository to worktree

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -153,23 +153,14 @@ setup_mcp_servers() {
     claude_cmd=$(get_claude_path)
     
     # Process each MCP server configuration
-    echo "$MCP_SERVERS" | while IFS='|' read -r server_name command args_rest; do
+    echo "$MCP_SERVERS" | while IFS='|' read -r server_name full_command; do
         # Skip empty lines
         [ -z "$server_name" ] && continue
         
-        # Convert the remaining args into an array
-        IFS='|' read -ra args_array <<< "$args_rest"
-        
         print_info "Adding MCP server: $server_name"
         
-        # Build the full command string with all arguments
-        local full_command="$command"
-        for arg in "${args_array[@]}"; do
-            full_command="$full_command $arg"
-        done
-        
         # Use claude mcp add command with local scope
-        # Pass the entire command as a single quoted string
+        # The full command is already provided as a single string
         if ! "$claude_cmd" mcp add --scope local "$server_name" "$full_command"; then
             print_error "Failed to add MCP server: $server_name"
         fi

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -162,8 +162,15 @@ setup_mcp_servers() {
         
         print_info "Adding MCP server: $server_name"
         
-        # Use claude mcp add command
-        if ! "$claude_cmd" mcp add --project "$worktree_path" "$server_name" "$command" "${args_array[@]}"; then
+        # Build the full command string with all arguments
+        local full_command="$command"
+        for arg in "${args_array[@]}"; do
+            full_command="$full_command $arg"
+        done
+        
+        # Use claude mcp add command with local scope
+        # Pass the entire command as a single quoted string
+        if ! "$claude_cmd" mcp add --scope local "$server_name" "$full_command"; then
             print_error "Failed to add MCP server: $server_name"
         fi
     done
@@ -325,16 +332,16 @@ main() {
     # Setup symlinks from configuration or defaults
     setup_symlinks "$worktree_path" "$git_root"
     
-    # Setup MCP servers for the worktree
+    # Navigate to worktree directory
+    cd "$worktree_path"
+    
+    # Setup MCP servers for the worktree (must be done after cd)
     setup_mcp_servers "$worktree_path" "$git_root"
     
     # Check if direnv is available and .envrc was symlinked
     if [ -L "${worktree_path}/.envrc" ] && command -v direnv &> /dev/null; then
         print_info "Running direnv allow..."
-        cd "$worktree_path"
         direnv allow
-    else
-        cd "$worktree_path"
     fi
 
     print_success "Worktree created successfully!"


### PR DESCRIPTION
## Summary
- Fixed MCP server configuration parsing issues in create-worktree script
- Simplified MCP_SERVERS configuration format to use just `name|full_command`
- Resolved "error: unknown option '-y'" issue when configuring MCP servers

## Problem
The create-worktree script was failing to properly configure MCP servers because:
1. It was using non-existent `--project` flag instead of `--scope local`
2. Arguments like `-y` were being interpreted as claude options
3. The script wasn't running from within the worktree directory

## Solution
1. **Use correct flag**: Changed from `--project` to `--scope local`
2. **Run from worktree**: Moved MCP setup after `cd` into worktree directory
3. **Pass full command**: Pass entire command as single quoted string to avoid option parsing issues
4. **Simplified format**: Changed config from `name|cmd|arg1|arg2|...` to `name|full_command`

## Changes
- Updated `setup_mcp_servers()` to use simplified parsing
- Modified `.claude-worktrees.rc` to use new format
- Updated documentation in CLAUDE.md

## Test plan
- [x] Tested with ROY-39 - MCP server configured successfully
- [x] Verified Linear MCP server connects properly in worktree
- [ ] Test with multiple MCP servers
- [ ] Test without .claude-worktrees.rc file (should skip gracefully)

🤖 Generated with [Claude Code](https://claude.ai/code)