### PR TITLE
[ROY-56] Handle existing MCP servers gracefully in create-worktree script

### DIFF
--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -161,8 +161,14 @@ setup_mcp_servers() {
         
         # Use claude mcp add command with local scope
         # The full command is already provided as a single string
-        if ! "$claude_cmd" mcp add --scope local "$server_name" "$full_command"; then
+        local output
+        if output=$("$claude_cmd" mcp add --scope local "$server_name" "$full_command" 2>&1); then
+            print_success "Added MCP server: $server_name"
+        elif echo "$output" | grep -q "already exists"; then
+            print_info "MCP server $server_name already configured, skipping"
+        else
             print_error "Failed to add MCP server: $server_name"
+            print_error "Error: $output"
         fi
     done
     


### PR DESCRIPTION
## Summary
Modified the create-worktree script to gracefully handle cases where MCP servers already exist, treating them as successful (skip) rather than errors.

## Problem
When running create-worktree on a directory that already has MCP servers configured, the script would fail with:
```
MCP server linear already exists in local config
Error: Failed to add MCP server: linear
```

This prevented re-running the script on existing worktrees or recovering from partial failures.

## Solution
Updated `setup_mcp_servers` function to:
1. Capture the output of `claude mcp add`
2. Check if the error contains "already exists"
3. If so, log an info message and continue (not an error)
4. Show detailed error messages for actual failures

## Test plan
- [x] Verified the code handles the output checking correctly
- [ ] Test creating a new worktree with MCP servers
- [ ] Test re-running on a worktree that already has MCP servers configured
- [ ] Test with an actual MCP server failure to ensure errors are still reported

🤖 Generated with [Claude Code](https://claude.ai/code)