### PR TITLE
[ROY-58] Migrate MCP server configuration from .claude-worktrees.rc to .mcp.json

### DIFF
--- a/.claude-worktrees.rc
+++ b/.claude-worktrees.rc
@@ -1,11 +1,5 @@
 # Configuration file for create-worktree script
-# This file defines MCP servers and files to symlink for git worktrees
-
-# MCP Server Configuration
-# Format: SERVER_NAME|FULL_COMMAND
-MCP_SERVERS="
-linear|npx -y mcp-remote https://mcp.linear.app/sse
-"
+# This file defines files to symlink for git worktrees
 
 # Files to symlink from main repository to worktree
 # One file per line

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "linear": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.linear.app/sse"
+      ]
+    }
+  }
+}

--- a/bin/create-worktree
+++ b/bin/create-worktree
@@ -126,55 +126,6 @@ setup_python_environment() {
     return 0
 }
 
-setup_mcp_servers() {
-    local worktree_path="$1"
-    local git_root="$2"
-    local config_file="${git_root}/.claude-worktrees.rc"
-    
-    # Check if configuration file exists
-    if [ ! -f "$config_file" ]; then
-        print_info "No .claude-worktrees.rc found, skipping MCP server setup"
-        return 0
-    fi
-    
-    # Source the configuration file
-    source "$config_file"
-    
-    # Check if MCP_SERVERS is defined and not empty
-    if [ -z "$MCP_SERVERS" ] || [ -z "$(echo "$MCP_SERVERS" | tr -d '[:space:]')" ]; then
-        print_info "No MCP servers configured in .claude-worktrees.rc"
-        return 0
-    fi
-    
-    print_info "Setting up MCP servers for worktree..."
-    
-    # Get claude command path
-    local claude_cmd
-    claude_cmd=$(get_claude_path)
-    
-    # Process each MCP server configuration
-    echo "$MCP_SERVERS" | while IFS='|' read -r server_name full_command; do
-        # Skip empty lines
-        [ -z "$server_name" ] && continue
-        
-        print_info "Adding MCP server: $server_name"
-        
-        # Use claude mcp add command with local scope
-        # The full command is already provided as a single string
-        local output
-        if output=$("$claude_cmd" mcp add --scope local "$server_name" "$full_command" 2>&1); then
-            print_success "Added MCP server: $server_name"
-        elif echo "$output" | grep -q "already exists"; then
-            print_info "MCP server $server_name already configured, skipping"
-        else
-            print_error "Failed to add MCP server: $server_name"
-            print_error "Error: $output"
-        fi
-    done
-    
-    print_success "MCP servers configured for worktree"
-    return 0
-}
 
 setup_symlinks() {
     local worktree_path="$1"
@@ -331,9 +282,6 @@ main() {
     
     # Navigate to worktree directory
     cd "$worktree_path"
-    
-    # Setup MCP servers for the worktree (must be done after cd)
-    setup_mcp_servers "$worktree_path" "$git_root"
     
     # Check if direnv is available and .envrc was symlinked
     if [ -L "${worktree_path}/.envrc" ] && command -v direnv &> /dev/null; then


### PR DESCRIPTION
## Summary
- Migrated MCP server configuration from custom format to standard .mcp.json
- Removed MCP server setup logic from create-worktree script (-49 lines)
- Tracked .mcp.json in git for team-wide consistency

## Changes

### 1. Created `.mcp.json`
- Standard Claude Code format for MCP server configuration
- Contains Linear MCP server setup

### 2. Updated `.claude-worktrees.rc`
- Removed MCP_SERVERS configuration section
- Simplified to only contain symlink files list

### 3. Updated `bin/create-worktree`
- Removed `setup_mcp_servers()` function entirely
- Removed call to setup_mcp_servers from main flow
- Cleaner, simpler script

## Benefits
- Uses Claude's native configuration format
- Simpler architecture with less custom code
- MCP configuration is now tracked in git and shared with team
- Follows Claude Code best practices

## Test Plan
- [x] All Python tests pass (101 passed)
- [x] Code quality checks pass (make dev-check)
- [x] create-worktree script still functions correctly
- [x] .mcp.json is valid JSON format

🤖 Generated with [Claude Code](https://claude.ai/code)